### PR TITLE
SVG支持任意大小二维码绘制

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -141,7 +141,7 @@ define(function(require, exports, module) {
 	 * 使用SVG开绘制二维码
 	 * @return {}
 	 */
-	qrcode.prototype = function createSVG(qrCodeAlg){
+	qrcode.prototype.createSVG = function (qrCodeAlg){
 	    var x, dx, y, dy,
 	    	  moduleCount = qrCodeAlg.getModuleCount(),
 	    	  scale = this.options.height / this.options.width,


### PR DESCRIPTION
设置viewBox缩放SVG实现任意大小的二维码！

详见https://github.com/aralejs/qrcode/pull/2

本次更新修复SVG二维码宽高只能是1:1的问题！
