### PR TITLE
[BGF]修复二维码中间的图片跨域导致canvas.toDataURL报错

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,7 @@ extend(qrcode.prototype,{
         // preload img
         var loadImage = function(url,callback){
             var img = new Image();
+            img.crossOrigin = 'Anonymous';
             img.src = url;
             img.onload = function () {
                 callback(this);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/37824056/105000590-7a02c580-5a69-11eb-9caf-2f9832bab79d.png)
如上图，设置二维码中间的图片是第三方网络资源图时，会报如下canvas里的图片跨域的错
![image](https://user-images.githubusercontent.com/37824056/105000474-59d30680-5a69-11eb-9364-2b38320790df.png)
修复：在loadImage方法里面设置crossOrigin 属性，允许跨域，虽然这只对静态资源服务器设置了access-control-allow-origin: *的图片有效，但还是可以满足大部分场景的需求